### PR TITLE
Include version when parsing requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 import codecs
 import os
-import re
 
 from setuptools import find_packages
 from setuptools import setup
@@ -26,9 +25,7 @@ def find_meta(key):
 def requirements(*paths):
     with open(os.path.join(here, *paths)) as f:
         reqs_txt = f.read()
-    parsed = [re.split(r'[<~=>]=?', r, maxsplit=2)[0]
-              for r in reqs_txt.splitlines() if not r.startswith('-f')]
-    return [r for r in parsed if r != '']
+    return [r for r in reqs_txt.splitlines() if r != '']
 
 
 def read(*paths, sep='\n', enc='utf-8'):


### PR DESCRIPTION
setup.py currently parses paths and returns an array that does not include versions.
This causes latest versions of packages to be used rather than the ones specified by
`paths`.

```python
>>> import re
>>> req='attrs==18.2.0\nclick==7.0\nPyGithub==1.43.3\nPyJWT==1.6.4\npyyaml==3.13\nrequests==2.20.0\nulogger==1.0.2\n'
>>> [re.split(r'[<~=>]=?', r, maxsplit=2)[0]
...   for r in req.splitlines() if not r.startswith('-f')]
['attrs', 'click', 'PyGithub', 'PyJWT', 'pyyaml', 'requests', 'ulogger']
>>> [r for r in req.splitlines() if r != '']
['attrs==18.2.0', 'click==7.0', 'PyGithub==1.43.3', 'PyJWT==1.6.4', 'pyyaml==3.13', 'requests==2.20.0', 'ulogger==1.0.2']
```

Fixes #10.

